### PR TITLE
Fix pandoc metadata check

### DIFF
--- a/src/hastyscribepkg/markdown.nim
+++ b/src/hastyscribepkg/markdown.nim
@@ -149,13 +149,13 @@ proc md*(s: string, f = 0, data: var TMDMetadata): string =
   var lns = s.splitLines
   var valid_metadata = false
   var offset = 0
-  if (lns[0][0] == '%') and (lns[1][0] == '%') and (lns[2][0] == '%'):
+  if lns[0].startsWith('%') and lns[1].startsWith('%') and lns[2].startsWith('%'):
     valid_metadata = true
   else:
     valid_metadata = false
-    if lns[0][0] == '%':
+    if lns[0].startsWith('%'):
       offset = 2
-      if lns[1][0] == '%':
+      if lns[1].startsWith('%'):
         offset = 3
   var str = cstring(lns[offset..lns.len-1].join("\n"))
   var mmiot = mkd_string(str, cint(str.len-1), flags)

--- a/src/hastyscribepkg/markdown.nim
+++ b/src/hastyscribepkg/markdown.nim
@@ -112,7 +112,9 @@ const
 
 ## High Level API
 
-import strutils
+import 
+  strutils,
+  pegs
 
 const 
   DefaultFlags = MKD_TOC or MKD_1_COMPAT or MKD_EXTRA_FOOTNOTE or MKD_DLEXTRA or MKD_FENCEDCODE or MKD_GITHUBTAGS or MKD_HTML5ANCHOR or MKD_LATEX
@@ -145,19 +147,23 @@ proc md*(s: string, f = 0, data: var TMDMetadata): string =
     flags = DefaultFlags
   else: 
     flags = uint32(f)
-  # Check if metadata is present
-  var lns = s.splitLines
+  # Check if Pandoc style metadata is present
   var valid_metadata = false
-  var offset = 0
-  if lns[0].startsWith('%') and lns[1].startsWith('%') and lns[2].startsWith('%'):
-    valid_metadata = true
-  else:
-    valid_metadata = false
-    if lns[0].startsWith('%'):
-      offset = 2
-      if lns[1].startsWith('%'):
-        offset = 3
-  var str = cstring(lns[offset..lns.len-1].join("\n"))
+  var contents = s
+  let peg_pandoc = peg"""
+    definition <- ^{line} {line}? {line}?
+    line <- '\%' @ \n
+  """
+  var matches: array[0..2, string] 
+  let (s, e) = contents.findBounds(peg_pandoc, matches)
+  # the pattern must start at the beginning of the file
+  if s == 0:
+    if matches[0] != "" and matches[1] != "" and matches[2] != "":
+      valid_metadata = true
+    else:
+      # incomplete metadata, remove the whole pandoc section to not confuse discount
+      contents = contents[e-1 .. ^1]  
+  var str = cstring(contents)
   var mmiot = mkd_string(str, cint(str.len-1), flags)
   if valid_metadata:
     data.title = $mkd_doc_title(mmiot)


### PR DESCRIPTION
I noticed problems when one of the first 3 lines of the document was empty. Then the check for `%` character failed. Additionally the whole content of the file was split into lines and then merged. I think it is more efficient to just truncate the beginning of the file. As the `s` parameter is not `var` I couldn't use `delete` which would change the input so the substring of the input is created. I wasn't also sure why this was done, I assume that _Discount_  was not able to handle it correctly if not all three lines started with `%`.