### PR TITLE
Add function for parsing YAML Front Matter metadata

### DIFF
--- a/src/hastyscribe.nim
+++ b/src/hastyscribe.nim
@@ -154,7 +154,7 @@ proc handleYamlMetadata*(contents: var string, metadata: var Table[string,string
   ## and the YAML section is removed from the contents 
   result = false
   let peg_yaml = peg"""
-    definition <- ^'---' \n {line+} '---' \n \n
+    definition <- ^'---' \n {line+} '---' \n
     line <- \s* id \s* ':' \s* @ \n
     id <- [a-zA-Z0-9_-]+
   """

--- a/src/hastyscribe.nim
+++ b/src/hastyscribe.nim
@@ -148,6 +148,35 @@ proc embed_fonts(): string=
   ]
   return style_tag(fonts.join);
 
+proc handleYamlMetadata*(contents: var string, metadata: var Table[string,string]): bool =
+  ## If the document starts with YAML Front Matters then defined metadata is 
+  ## returned in the metadata table as key value pairs
+  ## and the YAML section is removed from the contents 
+  result = false
+  let peg_yaml = peg"""
+    definition <- ^'---' \n {line+} '---' \n \n
+    line <- \s* id \s* ':' \s* @ \n
+    id <- [a-zA-Z0-9_-]+
+  """
+  var matches: array[0..0, string] 
+  let (s, e) = contents.findBounds(peg_yaml, matches)
+  # the pattern must start at the beginning of the file
+  if s == 0:
+    result = true
+    # eat whole YAML section from the content and parse key value pairs
+    contents.delete(0, e)
+    let yaml = matches[0]
+    let peg_key_value = peg"\s* {[a-zA-Z0-9_-]+} \s* ':' \s* {@} \n"
+    for key_value in yaml.findAll(peg_key_value):
+      var matches: array[0..1, string]
+      discard key_value.match(peg_key_value, matches)
+      let key = matches[0].strip
+      let value = matches[1].strip
+      if metadata.hasKey(key):
+        warn "Key $1 already defined with value $2"% [key, metadata[key]]
+      else:
+        metadata[key] = value
+
 proc preprocess*(hs: var HastyScribe, document, dir: string, offset = 0): string
 
 proc applyHeadingOffset(contents: string, offset: int): string =


### PR DESCRIPTION
This function is a simple parser for YAML metadata. It removes the YAML section from the beginning of the file so it can be processed by _Discount_ later. The metadata is returned in the provided `StringTable`. The function is not used in _HastyScribe_ (I wasn't sure you wanted it), I use it from my version of _LiteStore_. There all retrieved metadata is added as fields to be used inside the page.