### PR TITLE
Update broken anchor links in User Guide

### DIFF
--- a/doc/-syntax-block-classes.md
+++ b/doc/-syntax-block-classes.md
@@ -2,9 +2,9 @@
 
 ## Notes
 
-[Discount][discount] supports the definition of _class blocks_: [div](class:kwd)s with a class attribute. The syntax is very similar to the one used for [block quotes](#Block.Quotes), with the addition of the class name wrapped in [%](class:kwd)s on the first line. 
+[Discount][discount] supports the definition of _class blocks_: [div](class:kwd)s with a class attribute. The syntax is very similar to the one used for [block quotes](#Block-Quotes), with the addition of the class name wrapped in [%](class:kwd)s on the first line. 
 
-In {{hs}}, this syntax is used to produce notes, [tips](#Tips), [warmings](#Warnings), [sidebars](#Sidebars) and [terminal sessions](#Terminal.Sessions).
+In {{hs}}, this syntax is used to produce notes, [tips](#Tips), [warmings](#Warnings), [sidebars](#Sidebars) and [terminal sessions](#Terminal-Sessions).
 
 {{input-text}}
 

--- a/doc/-syntax-block.md
+++ b/doc/-syntax-block.md
@@ -14,7 +14,7 @@ Headings can be specified simply by prepending [#](class:kwd)s to text, as follo
 > %note%
 > Note
 > 
-> If you use [Document Headers](#Document.Headers), A [H1](class:kwd) is used for the title of the {{hs}} document. Within the document, start using headings from [H2](class:kwd).
+> If you use [Document Headers](#Document-Headers), A [H1](class:kwd) is used for the title of the {{hs}} document. Within the document, start using headings from [H2](class:kwd).
 
 ## Tables
 


### PR DESCRIPTION
The current links have a "." in between, rather than a "-". The correct version can already be seen in the Table of Contents (where it applies).