### PR TITLE
CLI fixes, multiple input files, output-dir, refactoring

### DIFF
--- a/src/hastyscribepkg/consts.nim
+++ b/src/hastyscribepkg/consts.nim
@@ -1,5 +1,5 @@
 
-const 
+const
   stylesheet* = "./data/hastystyles.css".slurp
   stylesheet_badges* = "./data/hastystyles.badges.css".slurp
   stylesheet_icons* = "./data/hastystyles.icons.css".slurp
@@ -26,3 +26,4 @@ const
   background-attachment: fixed;
 }
 """
+  eof_separator* = "<!-- $name: EOF -->"

--- a/src/hastyscribepkg/markdown.nim
+++ b/src/hastyscribepkg/markdown.nim
@@ -1,65 +1,65 @@
-const 
+const
   MKDIO_D* = true
-type 
+type
   MMIOT* = int
   mkd_flag_t* = cuint
 
 {.push importc, cdecl.}
 # line builder for markdown()
-# 
+#
 proc mkd_in*(a2: ptr FILE; a3: mkd_flag_t): ptr MMIOT
-# assemble input from a file 
+# assemble input from a file
 proc mkd_string*(a2: cstring; a3: cint; a4: mkd_flag_t): ptr MMIOT
-# assemble input from a buffer 
+# assemble input from a buffer
 # line builder for github flavoured markdown
-# 
+#
 proc gfm_in*(a2: ptr FILE; a3: mkd_flag_t): ptr MMIOT
-# assemble input from a file 
+# assemble input from a file
 proc gfm_string*(a2: cstring; a3: cint; a4: mkd_flag_t): ptr MMIOT
-# assemble input from a buffer 
+# assemble input from a buffer
 proc mkd_basename*(a2: ptr MMIOT; a3: cstring)
 proc mkd_initialize*()
 proc mkd_with_html5_tags*()
 proc mkd_shlib_destructor*()
 # compilation, debugging, cleanup
-# 
+#
 proc mkd_compile*(a2: ptr MMIOT; a3: mkd_flag_t): cint
 proc mkd_cleanup*(a2: ptr MMIOT)
 # markup functions
-# 
+#
 proc mkd_dump*(a2: ptr MMIOT; a3: ptr FILE; a4: cint; a5: cstring): cint
 proc markdown*(a2: ptr MMIOT; a3: ptr FILE; a4: mkd_flag_t): cint
 proc mkd_line*(a2: cstring; a3: cint; a4: cstringArray; a5: mkd_flag_t): cint
-type 
+type
   mkd_sta_function_t* = proc (a2: cint; a3: pointer): cint
-proc mkd_string_to_anchor*(a2: cstring; a3: cint; a4: mkd_sta_function_t; 
+proc mkd_string_to_anchor*(a2: cstring; a3: cint; a4: mkd_sta_function_t;
                            a5: pointer; a6: cint)
 proc mkd_xhtmlpage*(a2: ptr MMIOT; a3: cint; a4: ptr FILE): cint
 # header block access
-# 
+#
 proc mkd_doc_title*(a2: ptr MMIOT): cstring
 proc mkd_doc_author*(a2: ptr MMIOT): cstring
 proc mkd_doc_date*(a2: ptr MMIOT): cstring
 # compiled data access
-# 
+#
 proc mkd_document*(a2: ptr MMIOT; a3: cstringArray): cint
 proc mkd_toc*(a2: ptr MMIOT; a3: cstringArray): cint
 proc mkd_css*(a2: ptr MMIOT; a3: cstringArray): cint
 proc mkd_xml*(a2: cstring; a3: cint; a4: cstringArray): cint
 # write-to-file functions
-# 
+#
 proc mkd_generatehtml*(a2: ptr MMIOT; a3: ptr FILE): cint
 proc mkd_generatetoc*(a2: ptr MMIOT; a3: ptr FILE): cint
 proc mkd_generatexml*(a2: cstring; a3: cint; a4: ptr FILE): cint
 proc mkd_generatecss*(a2: ptr MMIOT; a3: ptr FILE): cint
-const 
+const
   mkd_style* = mkd_generatecss
 proc mkd_generateline*(a2: cstring; a3: cint; a4: ptr FILE; a5: mkd_flag_t): cint
-const 
+const
   mkd_text* = mkd_generateline
 # url generator callbacks
-# 
-type 
+#
+type
   mkd_callback_t* = proc (a2: cstring; a3: cint; a4: pointer): cstring
   mkd_free_t* = proc (a2: cstring; a3: pointer)
 proc mkd_e_url*(a2: pointer; a3: mkd_callback_t)
@@ -67,7 +67,7 @@ proc mkd_e_flags*(a2: pointer; a3: mkd_callback_t)
 proc mkd_e_free*(a2: pointer; a3: mkd_free_t)
 proc mkd_e_data*(a2: pointer; a3: pointer)
 # version#.
-# 
+#
 var markdown_version*: ptr char
 proc mkd_mmiot_flags*(a2: ptr FILE; a3: ptr MMIOT; a4: cint)
 proc mkd_flags_are*(a2: ptr FILE; a3: mkd_flag_t; a4: cint)
@@ -75,8 +75,8 @@ proc mkd_ref_prefix*(a2: ptr MMIOT; a3: cstring)
 {.pop.}
 
 # special flags for markdown() and mkd_text()
-# 
-const 
+#
+const
   MKD_NOLINKS* = 0x00000001
   MKD_NOIMAGE* = 0x00000002
   MKD_NOPANTS* = 0x00000004
@@ -111,24 +111,24 @@ const
 
 ## High Level API
 
-import 
+import
   std/pegs
 
-const 
-  DefaultFlags = MKD_TOC or MKD_1_COMPAT or MKD_EXTRA_FOOTNOTE or MKD_DLEXTRA or MKD_FENCEDCODE or MKD_GITHUBTAGS or MKD_URLENCODEDANCHOR  or MKD_LATEX 
+const
+  DefaultFlags = MKD_TOC or MKD_1_COMPAT or MKD_EXTRA_FOOTNOTE or MKD_DLEXTRA or MKD_FENCEDCODE or MKD_GITHUBTAGS or MKD_URLENCODEDANCHOR  or MKD_LATEX
 
-type TMDMetaData* = object 
-  title*: string
-  author*: string
-  date*: string
-  toc*: string
-  css*: string
+type TMDMetaData* = object
+  title*: string = ""
+  author*: string = ""
+  date*: string = ""
+  toc*: string = ""
+  css*: string = ""
 
 proc md*(s: string, f = 0): string =
   var flags: uint32
   if (f == 0):
     flags = DefaultFlags
-  else: 
+  else:
     flags = uint32(f)
   var str = cstring(s&" ")
   var mmiot = mkd_string(str, cint(str.len-1), flags)
@@ -139,11 +139,12 @@ proc md*(s: string, f = 0): string =
   mkd_cleanup(mmiot)
   return
 
-proc md*(s: string, f = 0, data: var TMDMetadata): string =
+proc md*(s: string, f = 0; data: out TMDMetaData): string =
+  data = default(TMDMetaData)
   var flags: uint32
   if (f == 0):
     flags = DefaultFlags
-  else: 
+  else:
     flags = uint32(f)
   # Check if Pandoc style metadata is present
   var valid_metadata = false
@@ -152,7 +153,7 @@ proc md*(s: string, f = 0, data: var TMDMetadata): string =
     definition <- ^{line} {line}? {line}?
     line <- '\%' @ \n
   """
-  var matches: array[0..2, string] 
+  var matches: array[0..2, string]
   let (s, e) = contents.findBounds(peg_pandoc, matches)
   # the pattern must start at the beginning of the file
   if s == 0:
@@ -160,7 +161,7 @@ proc md*(s: string, f = 0, data: var TMDMetadata): string =
       valid_metadata = true
     else:
       # incomplete metadata, remove the whole pandoc section to not confuse discount
-      contents = contents[e-1 .. ^1]  
+      contents = contents[e-1 .. ^1]
   var str = cstring(contents)
   var mmiot = mkd_string(str, cint(str.len), flags)
   if valid_metadata:
@@ -173,18 +174,15 @@ proc md*(s: string, f = 0, data: var TMDMetadata): string =
     var toc = allocCStringArray(@[""])
     if mkd_toc(mmiot, toc) > 0:
       data.toc = cstringArrayToSeq(toc)[0]
-    else:
-      data.toc = ""
   # Process CSS
-  var css = allocCStringArray(newSeq[string](10))
-  if mkd_css(mmiot, css) > 0:
-    data.css = cstringArrayToSeq(css)[0]
-  else:
-    data.css = ""
+  data.css = block:
+    var css = allocCStringArray(newSeq[string](10))
+    if mkd_css(mmiot, css) > 0: cstringArrayToSeq(css)[0]
+    else: ""
   # Generate HTML
-  var res = allocCStringArray([""])
-  if mkd_document(mmiot, res) > 0:
-    result = cstringArrayToSeq(res)[0]
-  else:
-    result = ""
+  let html = block:
+    var res = allocCStringArray([""])
+    if mkd_document(mmiot, res) > 0: cstringArrayToSeq(res)[0]
+    else: ""
   mkd_cleanup(mmiot)
+  html

--- a/src/hastyscribepkg/niftylogger.nim
+++ b/src/hastyscribepkg/niftylogger.nim
@@ -1,13 +1,14 @@
-import 
-  std/logging,
-  std/strutils,
-  std/terminal,
-  std/exitprocs
+import std/[
+    logging,
+    strutils,
+    terminal,
+    exitprocs,
+  ]
 
 if isatty(stdin):
   addExitProc(resetAttributes)
 
-type  
+type
   NiftyLogger* = ref object of Logger
 
 proc logPrefix*(level: Level): tuple[msg: string, color: ForegroundColor] =
@@ -17,7 +18,7 @@ proc logPrefix*(level: Level): tuple[msg: string, color: ForegroundColor] =
     of lvlInfo:
       return ("(i)", fgCyan)
     of lvlNotice:
-      return ("   ", fgWhite)
+      return ("   ", fgBlue)
     of lvlWarn:
       return ("(!)", fgYellow)
     of lvlError:
@@ -25,12 +26,12 @@ proc logPrefix*(level: Level): tuple[msg: string, color: ForegroundColor] =
     of lvlFatal:
       return ("(x)", fgRed)
     else:
-      return ("   ", fgWhite)
+      return ("   ", fgDefault)
 
 method log*(logger: NiftyLogger; level: Level; args: varargs[string, `$`]) =
   var f = stdout
   if level >= getLogFilter() and level >= logger.levelThreshold:
-    if level >= lvlWarn: 
+    if level >= lvlWarn:
       f = stderr
     let ln = substituteLog(logger.fmtStr, level, args)
     let prefix = level.logPrefix()

--- a/src/hastyscribepkg/utils.nim
+++ b/src/hastyscribepkg/utils.nim
@@ -1,8 +1,9 @@
-import
-  std/base64,
-  std/os,
-  std/strutils,
-  std/pegs
+import std/[
+    base64,
+    os,
+    strutils,
+    pegs,
+  ]
 
 import
   consts
@@ -14,19 +15,20 @@ proc style_link_tag*(css: string): string =
   result = "<link rel=\"stylesheet\" href=\"$1\"/>" % [css]
 
 proc encode_image*(contents, format: string): string =
-    if format == "svg":
-      let encoded_svg = contents
-        .replace("\"", "'")
-        .replace("%", "%25")
-        .replace("#", "%23")
-        .replace("{", "%7B")
-        .replace("}", "%7D")
-        .replace("<", "%3C")
-        .replace(">", "%3E")
-        .replace(" ", "%20")
-      return "data:image/svg+xml,$#" % [encoded_svg]
-    else:
-      return "data:image/$format;base64,$enc_contents" % ["format", format, "enc_contents", contents.encode]
+  if format == "svg":
+    let encoded_svg = contents.multireplace([
+        ("\"", "'"),
+        ("%", "%25"),
+        ("#", "%23"),
+        ("{", "%7B"),
+        ("}", "%7D"),
+        ("<", "%3C"),
+        (">", "%3E"),
+        (" ", "%20"),
+      ])
+    "data:image/svg+xml,$#" % [encoded_svg]
+  else:
+    "data:image/$format;base64,$enc_contents" % ["format", format, "enc_contents", contents.encode]
 
 proc encode_image_file*(file, format: string): string =
   if (file.fileExists):

--- a/src/hastyscribepkg/utils.nim
+++ b/src/hastyscribepkg/utils.nim
@@ -3,6 +3,7 @@ import std/[
     os,
     strutils,
     pegs,
+    hashes,
   ]
 
 import
@@ -51,3 +52,14 @@ proc watermark_css*(imgfile: string): string =
 
 proc add_jump_to_top_links*(document: string): string =
   result = document.replacef(peg"{'</h' [23456] '>'}", "<a href=\"#document-top\" title=\"Go to top\"></a>$1")
+
+proc makeFNameUnique*(baseName, dir: string): string =
+  ## Uses file placement (`dir`) as a unique name identifier
+  ## Files in relative root (`dir` is empty) are returned unchanged.
+  if dir notin ["", ".", "./"]:
+    let
+      dir = when dosLikeFileSystem: dir.replace('\\', '/') else: dir
+      hashBytes = cast[array[sizeof(Hash), byte]](hash(dir))
+      uniquePrefix = encode(hashBytes, safe=true)
+    baseName & '_' & uniquePrefix
+  else: baseName

--- a/src/hastyscribepkg/utils.nim
+++ b/src/hastyscribepkg/utils.nim
@@ -8,8 +8,8 @@ import std/[
 import
   consts
 
-proc style_tag*(css: string): string =
-  result = "<style>$1</style>" % [css]
+template style_tag*(css: string): string =
+  "<style>" & css & "</style>"
 
 proc style_link_tag*(css: string): string =
   result = "<link rel=\"stylesheet\" href=\"$1\"/>" % [css]


### PR DESCRIPTION
Great little program!

I've looked around a bit see how to implement a couple of things I need and made a few changes. I tried to not change any behaviour so nothing breaks, but a few of the following changes could be considered breaking. I've marked those with bold.

- Now **multiple input files are handled** correctly, including **multiple glob patterns**.
- IOError **exit code changed to `5`**.
- `output-file` with multiple input files **now ignored, preventing repeated overwrites**.
- More events are now logged, including successful conversions and invalid arguments.
- `HastyOptions` now uses default fields for initialization.
- `std/critbits` are now imported to deduplicate input arguments.
- `TMDMetaData` now uses default object fields for initialization and is now an `out` parameter of `markdown.md`.
- ~~`sequtils.mapIt` consecutive usage merged.~~ superseded with [9a523af](https://github.com/h3rald/hastyscribe/pull/90/commits/9a523af528d5f43789fde0d9e64b7835c615d66e)
- Image download warning now outputs one log mark per message.
- `compileDocument` refactored to not use accumulation variables.
- `hastyscribe_logo` svg and img tag now prepared at compile time.
- Log level `lvNotice` now uses a dedicated color
- Normal log color changed from `fgWhite` to `fgDefault`
- `utils.encode_image` now uses `strutils.multireplace`
- Logic for some replacement operations relies on slightly tuned pegs, mostly to avoid multiple passes of `findAll`.
- `style_tag` is now a template
- Program now quits with an error if flags are given any value.
- Writing multiple files to stdout is now logged and **delimited with an html-comment** denoting the end of each file.
- Empty `--output-file` value is now an error.

Some new user-facing options are implemented:
- Added option `--iso` is added to allow printing the date in ISO 8601 format in the html footer.
- Added option `--no-clobber` to prevent overwrites.
- Added option `--output-dir` allowing writing the resulting html files to a  user-provided directory. If multiple given paths/globs resolve  to files with colliding basenames, files are saved with a path hash suffix to prevent overwrites.
  This option takes precedence over `--output-file`.

~~I'd like to add support for honoring program working directory or maybe outputting html files to a separate configurable directory, and there are a few options to do it, but they all are a bit more intrusive, so~~ I'd like to hear your opinion ~~first~~. [upd: implemented]

Thanks!