### PR TITLE
Basic css minifier for the built-in stylesheet

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Where:
   - **--noembed** causes styles and images not to be embedded.
   - **--fragment** causes HastyScribe to output just an HTML fragment instead of a full document, without embedding any image, font or stylesheet.
   - **--iso** enables HastyScribe to use the ISO 8601 date format (e.g., 2000-12-31) in the footer of the generated HTML documents.
+  - **--minify-css** uses an unsophisticated minifier on the built-in stylesheet before embedding it into HTML. Ignored when combined with `--noembed`.
   - **--no-clobber** or **-n** prevents HastyScribe from overwriting existing files. If a file with the same name already exists, HastyScribe will issue a warning and will not overwrite it.
   - **--help** causes HastyScribe to display the usage information and quit.
 

--- a/doc/-usage.md
+++ b/doc/-usage.md
@@ -19,6 +19,7 @@ Where:
     * [\-\-notoc](class:opt) causes {{hs}} to output HTML documents _without_ automatically generating a Table of Contents at the start.
     * [\-\-noembed](class:opt) causes styles and images not to be embedded.
     * [\-\-fragment](class:opt) causes {{hs}} to output just an HTML fragment instead of a full document, without embedding any image, font or stylesheet.
+    * [\-\-minify-css](class:opt) uses an unsophisticated minifier on the built-in stylesheet before embedding it into HTML. Ignored when combined with [\-\-noembed](class:opt).
     * [\-\-iso](class:opt) enables {{hs}} to use the ISO 8601 date format (e.g., 2000-12-31) in the footer of the generated HTML documents.
     * [\-\-no-clobber](class:opt) or [\-n](class:opt) prevents {{hs}} from overwriting existing files. If a file with the same name already exists, {{hs}} will issue a warning and will not overwrite it.
     * [\-\-help](class:opt) causes {{hs}} to display the usage information and quit.

--- a/src/hastyscribepkg/utils.nim
+++ b/src/hastyscribepkg/utils.nim
@@ -63,3 +63,12 @@ proc makeFNameUnique*(baseName, dir: string): string =
       uniquePrefix = encode(hashBytes, safe=true)
     baseName & '_' & uniquePrefix
   else: baseName
+
+proc minifyCss*(css: string): string =
+  css.parallelReplace([
+    (peg" '/*' @ '*/'", ""),
+    (peg" {\w} \s* {[ \>\< ]} \s* {\w / '*'} ", "$1$2$3" ),
+    (peg" \s* { [ \,\{\}\[\]\:\; ] } \s* ", "$1"),
+    (peg" \s+ ", " "),
+    (peg""" ')' \s* \" """, ")\"" ),
+  ])


### PR DESCRIPTION
Runs on `pegs.multireplace` and is very basic: deals only with whitespace and comments.

Doesn't know anything about quoted strings in CSS!

8.55KB for the current `hastystyles.css`, which is a 34% reduction.

I've tested the resulting CSS with the [W3C Jigsaw](https://jigsaw.w3.org/css-validator/) with no complaints, but performed no other tests.